### PR TITLE
Get github workflows working again.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
                   hatch test --cover
             - name: Run Flake8
               run: |
-                  hatch run test:flake8 --max-line-length=120 aptly_api
-            - name: Run mypy
+                  hatch fmt -l
+            - name: Static Type Checking
               run: |
                   hatch run mypy:type-check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
             - name: Run Tests
               run: |
                   hatch test --cover
-            - name: Run Flake8
+            - name: Lint
               run: |
                   hatch fmt -l
             - name: Static Type Checking

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,4 @@ jobs:
                   hatch run test:flake8 --max-line-length=120 aptly_api
             - name: Run mypy
               run: |
-                  hatch run test:mypy --install-types --non-interactive \
-                       --ignore-missing-imports --follow-imports=skip --disallow-untyped-calls \
-                       --disallow-untyped-defs -p aptly_api
+                  hatch run mypy:type-check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,20 +12,16 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             max-parallel: 4
-            matrix:
-                python-version: ["3.11", "3.12"]
 
         steps:
             - uses: actions/checkout@v4
-            - name: Set up Python ${{ matrix.python-version }}
+            - name: Set up Python
               uses: actions/setup-python@v5
-              with:
-                  python-version: ${{ matrix.python-version }}
             - name: Install Hatch
               run: pipx install hatch
             - name: Run Tests
               run: |
-                  hatch test --cover
+                  hatch test --all --cover
             - name: Lint
               run: |
                   hatch fmt -l

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
                   hatch test --all --cover
             - name: Lint
               run: |
-                  hatch fmt -l
+                  hatch fmt --linter --check
             - name: Static Type Checking
               run: |
                   hatch run mypy:type-check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,9 +28,9 @@ jobs:
                   hatch test --cover
             - name: Run Flake8
               run: |
-                  hatch run flake8 --max-line-length=120 aptly_api
+                  hatch run test:flake8 --max-line-length=120 aptly_api
             - name: Run mypy
               run: |
-                  hatch run mypy --install-types --non-interactive \
+                  hatch run test:mypy --install-types --non-interactive \
                        --ignore-missing-imports --follow-imports=skip --disallow-untyped-calls \
                        --disallow-untyped-defs -p aptly_api

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,9 +43,6 @@ packages = [
 default-args = []
 dependencies = [
     "requests-mock==1.12.1",
-    "coverage==7.6.0",
-    "coveralls==4.0.1",
-    "flake8==7.1.0",
     "pep257==0.7.0",
     "doc8==1.1.1",
     "Pygments==2.18.0",
@@ -62,6 +59,34 @@ pythonpath = [
 ]
 testpaths = [
     "aptly_api/tests/",
+]
+
+
+[tool.ruff]
+line-length = 120
+
+[tool.ruff.lint]
+ignore = [
+    "PT009",
+    "PT027",
+    "ARG002",
+    "SLF001",
+    "UP031",
+    "FA100",
+    "FBT001",
+    "FBT002",
+    "PERF401",
+    "EM101",
+    "TRY003",
+    "TRY302",
+    "A002",
+    "RET505",
+    "PLC0414",
+    "N818",
+    "SIM108",
+    "PLR2004",
+    "B007",
+    "SIM115",
 ]
 
 [tool.hatch.envs.mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,6 @@ dependencies = [
     "pep257==0.7.0",
     "doc8==1.1.1",
     "Pygments==2.18.0",
-    "mypy==1.10.1",
     "pytest==8.2.2",
     "pytest-cov==5.0.0",
 ]
@@ -64,4 +63,19 @@ pythonpath = [
 testpaths = [
     "aptly_api/tests/",
 ]
+
+[tool.hatch.envs.mypy]
+detatched = true
+dependencies = [
+    "mypy==1.10.1"
+]
+
+[tool.hatch.envs.mypy.scripts]
+type-check = "mypy --install-types --non-interactive -p aptly_api"
+
+[tool.mypy]
+ignore_missing_imports = true
+follow_imports = "skip"
+disallow_untyped_calls = true
+disallow_untyped_defs  = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,9 @@ ignore = [
     "PLR2004",
     "B007",
     "SIM115",
+    "UP009",
+    "UP014",
+    "I001",
 ]
 
 [tool.hatch.envs.mypy]


### PR DESCRIPTION
Get github workflows working again.

Switch from flake8 to ruff.
Add mypy to project.toml.
Hatch handling testing across different versions of python instead of github workflow.